### PR TITLE
Add support for linux/arm64 platform

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -46,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Por padrão, o docker builda pra arquitetura do sistema que está rodando ele.
Esse PR especifica o suporte pra amd64 e adiciona também para arm64. 

Exemplo da imagem gerada ->
https://hub.docker.com/r/joseiedo/trouble-box

Pipeline rodou certinho no fork ->
https://github.com/joseiedo/trouble-box/actions/runs/15352985991